### PR TITLE
Fix warnings when compiling for x86_64

### DIFF
--- a/NSString+EscapeString.m
+++ b/NSString+EscapeString.m
@@ -47,7 +47,7 @@
 -(NSString*)    escapedStringUppercase: (BOOL)uc
 {
     NSMutableString*    outStr = [NSMutableString string];
-    int                 x, count = [self length];
+    NSInteger			x, count = [self length];
     
     for( x = 0; x < count; x++ )
     {
@@ -91,7 +91,7 @@
 -(NSString*)    unescapedString
 {
     NSMutableString*    outStr = [NSMutableString string];
-    int                 x, count = [self length];
+    NSInteger			x, count = [self length];
     
     for( x = 0; x < count; x++ )
     {

--- a/UKColumnRowFilledBgView.m
+++ b/UKColumnRowFilledBgView.m
@@ -47,9 +47,9 @@
 -(void)	drawRect: (NSRect)rect
 {
 	NSRect		currBox = [self bounds];
-	int			rowColorIndexX = 0, rowColorIndexY = 0;
+	NSInteger	rowColorIndexY = 0;
 	NSArray*	rowCols = [NSColor controlAlternatingRowBackgroundColors];
-	int			numRowCols = [rowCols count];
+	NSInteger	numRowCols = [rowCols count];
 	NSColor*	darkeningColor = [NSColor colorWithCalibratedRed: 0.1 green: 0.2 blue: 0.7 alpha: 1.0];
 	
 	currBox.size.width = 0;
@@ -59,12 +59,6 @@
 		rowColorIndexY = 0;
 		currBox.origin.y = [self bounds].size.height;
 		currBox.size.height = 0;
-		
-		NSColor*	currColX = [rowCols objectAtIndex: rowColorIndexX];
-		if( rowColorIndexX < (numRowCols -1) )
-			rowColorIndexX++;
-		else
-			rowColorIndexX = 0;
 		currBox.origin.x += currBox.size.width;
 		currBox.size.width = colWidths[x];
 		

--- a/UKWindowBodyView.m
+++ b/UKWindowBodyView.m
@@ -49,7 +49,7 @@
 {
 	if( [eswin respondsToSelector: @selector(setContentBorderThickness:forEdge:)] )
 	{
-		if( [eswin styleMask] & NSTexturedBackgroundWindowMask )	// Can't set top edge of non-textured windows as of 10.5.2.
+		if( [eswin styleMask] & NSWindowStyleMaskTexturedBackground )	// Can't set top edge of non-textured windows as of 10.5.2.
 		{
 			[eswin setAutorecalculatesContentBorderThickness: NO forEdge:NSMaxYEdge];
 			float	desiredTopBorderHeight = [[eswin contentView] bounds].size.height -NSMaxY([self frame]);


### PR DESCRIPTION
- int have been changed to NSInteger
- Unneeded code removed
- Deprecated NSTexturedBackgroundWindowMask replaced by NSWindowStyleMaskTexturedBackground