### PR TITLE
Update UKXattrMetadataStore.[mh] again

### DIFF
--- a/UKXattrMetadataStore.h
+++ b/UKXattrMetadataStore.h
@@ -63,11 +63,27 @@ NS_ASSUME_NONNULL_BEGIN
 				The file to get xattr names from.
 	@param		travLnk
 				If <code>YES</code>, follows symlinks.
-	@return		An \c NSArray of <code>NSString</code>s, or \c nil on failure.
+	@return		An \c NSArray of <code>NSString</code>s, or an empty array on failure.
 	@discussion	Returns an \c NSArray of <code>NSString</code>s containing all xattr names currently set
 				for the file at the specified path.
  */
-+(NSArray<NSString*>*) allKeysAtPath: (NSString*)path traverseLink: (BOOL)travLnk NS_SWIFT_NAME(keys(path:traverseLink:));
++(NSArray<NSString*>*) allKeysAtPath: (NSString*)path traverseLink: (BOOL)travLnk DEPRECATED_MSG_ATTRIBUTE("Use '+allKeysAtPath:traverseLink:error:' instead.") NS_SWIFT_UNAVAILABLE("");
+
+/*!
+	@method		allKeysAtPath:traverseLink:
+	@param		path
+				The file to get xattr names from.
+	@param		travLnk
+				If <code>YES</code>, follows symlinks.
+	@param		error
+				If the method does not complete successfully, upon return
+				contains an \c NSError object that describes the problem.
+	@return		An \c NSArray of <code>NSString</code>s, or \c nil on failure.
+	@discussion	Returns an \c NSArray of <code>NSString</code>s containing all xattr names currently set
+				for the file at the specified path. Will return an empty \c NSArray if the file does not
+				have any extended attributes.
+ */
++(nullable NSArray<NSString*>*) allKeysAtPath: (NSString*)path traverseLink: (BOOL)travLnk error:(NSError**)error NS_SWIFT_NAME(keys(path:traverseLink:));
 
 
 #pragma mark Store UTF8 strings:

--- a/UKXattrMetadataStore.h
+++ b/UKXattrMetadataStore.h
@@ -103,7 +103,7 @@ NS_ASSUME_NONNULL_BEGIN
 	@deprecated	This method throws an Obj-C exception. No other error information is provided, not even if it was successful.
  */
 +(void) setString: (NSString*)str forKey: (NSString*)key
-		   atPath: (NSString*)path traverseLink: (BOOL)travLnk DEPRECATED_MSG_ATTRIBUTE("Use '-setString:forKey:atPath:traverseLink:error:' instead.") NS_SWIFT_UNAVAILABLE("Use 'setString(_:forKey:atPath:traverseLink:) throws' instead");
+		   atPath: (NSString*)path traverseLink: (BOOL)travLnk DEPRECATED_MSG_ATTRIBUTE("Use '+setString:forKey:atPath:traverseLink:error:' instead.") NS_SWIFT_UNAVAILABLE("Use 'setString(_:forKey:atPath:traverseLink:) throws' instead");
 
 /*!
 	@method		setString:forKey:atPath:traverseLink:error:
@@ -139,7 +139,7 @@ NS_ASSUME_NONNULL_BEGIN
 	@deprecated	This method has no error handling.
  */
 +(nullable NSString*) stringForKey: (NSString*)key atPath: (NSString*)path
-					  traverseLink: (BOOL)travLnk DEPRECATED_MSG_ATTRIBUTE("Use '-stringForKey:atPath:traverseLink:error:' instead.") NS_SWIFT_UNAVAILABLE("Use 'string(forKey:atPath:traverseLink:) throws' instead");
+					  traverseLink: (BOOL)travLnk DEPRECATED_MSG_ATTRIBUTE("Use '+stringForKey:atPath:traverseLink:error:' instead.") NS_SWIFT_UNAVAILABLE("Use 'string(forKey:atPath:traverseLink:) throws' instead");
 
 /*!
 	@method		stringForKey:atPath:traverseLink:error:
@@ -176,7 +176,7 @@ NS_ASSUME_NONNULL_BEGIN
 	@deprecated	This method has no way of indicating success or failure.
  */
 +(void) setData: (NSData*)data forKey: (NSString*)key
-		 atPath: (NSString*)path traverseLink: (BOOL)travLnk DEPRECATED_MSG_ATTRIBUTE("Use '-setData:forKey:atPath:traverseLink:error:' instead.") NS_SWIFT_UNAVAILABLE("Use 'setData(_:forKey:atPath:traverseLink:) throws' instead");
+		 atPath: (NSString*)path traverseLink: (BOOL)travLnk DEPRECATED_MSG_ATTRIBUTE("Use '+setData:forKey:atPath:traverseLink:error:' instead.") NS_SWIFT_UNAVAILABLE("Use 'setData(_:forKey:atPath:traverseLink:) throws' instead");
 /*!
 	@method		setData:forKey:atPath:traverseLink:error:
 	@brief		Set the xattr with name \c key to the raw data in <code>data</code>.
@@ -211,7 +211,7 @@ NS_ASSUME_NONNULL_BEGIN
 	@deprecated	This method throws an Obj-C exception. No other error information is provoded on failure.
  */
 +(nullable NSData*) dataForKey: (NSString*)key atPath: (NSString*)path
-				  traverseLink: (BOOL)travLnk DEPRECATED_MSG_ATTRIBUTE("Use '-dataForKey:atPath:traverseLink:error:' instead.") NS_SWIFT_UNAVAILABLE("Use 'data(forKey:atPath:traverseLink:) throws' instead");
+				  traverseLink: (BOOL)travLnk DEPRECATED_MSG_ATTRIBUTE("Use '+dataForKey:atPath:traverseLink:error:' instead.") NS_SWIFT_UNAVAILABLE("Use 'data(forKey:atPath:traverseLink:) throws' instead");
 /*!
 	@method		dataForKey:atPath:traverseLink:error:
 	@brief		Get the xattr with name \c key as raw data.
@@ -247,7 +247,7 @@ NS_ASSUME_NONNULL_BEGIN
 				not even if it was successful.
  */
 +(void) setObject: (id)obj forKey: (NSString*)key atPath: (NSString*)path
-	 traverseLink: (BOOL)travLnk DEPRECATED_MSG_ATTRIBUTE("Use '-setPlist:asXMLForKey:atPath:traverseLink:error:' instead.") NS_SWIFT_UNAVAILABLE("Use 'setPlistAsXML(_:key:path:traverseLink:) throws' instead");
+	 traverseLink: (BOOL)travLnk DEPRECATED_MSG_ATTRIBUTE("Use '+setPlist:asXMLForKey:atPath:traverseLink:error:' instead.") NS_SWIFT_UNAVAILABLE("Use 'setPlistAsXML(_:key:path:traverseLink:) throws' instead");
 
 /*!
 	@method		setPlist:asXMLForKey:atPath:traverseLink:error:
@@ -283,7 +283,7 @@ property list representation of
 	@deprecated	This method throws an Obj-C exception. No other error information is provided,
 				not even if it was successful.
  */
-+(nullable id) objectForKey: (NSString*)key atPath: (NSString*)path traverseLink:(BOOL)travLnk DEPRECATED_MSG_ATTRIBUTE("Use '-plistForXMLInKey:atPath:traverseLink:error:' instead.") NS_SWIFT_UNAVAILABLE("Use 'plistFromXML(key:path:traverseLink:) throws' instead");
++(nullable id) objectForKey: (NSString*)key atPath: (NSString*)path traverseLink:(BOOL)travLnk DEPRECATED_MSG_ATTRIBUTE("Use '+plistForXMLInKey:atPath:traverseLink:error:' instead.") NS_SWIFT_UNAVAILABLE("Use 'plistFromXML(key:path:traverseLink:) throws' instead");
 
 /*!
 	@method		plistForXMLInKey:atPath:traverseLink:error:

--- a/UKXattrMetadataStore.h
+++ b/UKXattrMetadataStore.h
@@ -83,7 +83,7 @@ NS_ASSUME_NONNULL_BEGIN
 				for the file at the specified path. Will return an empty \c NSArray if the file does not
 				have any extended attributes.
  */
-+(nullable NSArray<NSString*>*) allKeysAtPath: (NSString*)path traverseLink: (BOOL)travLnk error:(NSError**)error NS_SWIFT_NAME(keys(path:traverseLink:));
++(nullable NSArray<NSString*>*) allKeysAtPath: (NSString*)path traverseLink: (BOOL)travLnk error:(NSError * _Nullable __autoreleasing * _Nullable)error NS_SWIFT_NAME(keys(path:traverseLink:));
 
 
 #pragma mark Store UTF8 strings:

--- a/UKXattrMetadataStore.m
+++ b/UKXattrMetadataStore.m
@@ -46,10 +46,9 @@ const NSInteger ULIMaxXAttrKeyLength = 127;
 
 @implementation UKXattrMetadataStore
 
-
 +(NSArray*) allKeysAtPath: (NSString*)path traverseLink:(BOOL)travLnk
 {
-	NSArray *tmpArray = [self allkeysAtPath: path traverseLink: travLink error: NULL];
+	NSArray *tmpArray = [self allKeysAtPath: path traverseLink: travLnk error: NULL];
 	if (tmpArray == nil) {
 		return @[];
 	}
@@ -57,7 +56,7 @@ const NSInteger ULIMaxXAttrKeyLength = 127;
 }
 
 
-+(NSArray*) allKeysAtPath: (NSString*)path traverseLink:(BOOL)travLnk
++(NSArray*) allKeysAtPath: (NSString*)path traverseLink:(BOOL)travLnk error:(NSError * _Nullable __autoreleasing * _Nullable)error
 {
 	NSMutableArray<NSString*>*	allKeys = [NSMutableArray array];
 	ssize_t dataSize = listxattr( [path fileSystemRepresentation],


### PR DESCRIPTION
This adds a new getter for the key names, this time with an error pointer in case there's an error.

This also fixes a bug where `listxattr` and `getxattr` return a `ssize_t`, but we were storing it to a `size_t`. This should remove the need for checking for `ULONG_MAX`.

Another idea I have is to allow a developer to select a custom property list format for saving to xattrs.